### PR TITLE
OIF-11 dhis2_etl module tests break CI

### DIFF
--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2017-latest

--- a/dhis2_etl/adx_transform/adx_models/adx_definition.py
+++ b/dhis2_etl/adx_transform/adx_models/adx_definition.py
@@ -25,7 +25,7 @@ class ADXMappingDataValueDefinition:
     data_element: str
     aggregation_func: Callable[[QuerySet], str]
     dataset_from_orgunit_func: Callable[[Model], QuerySet]
-    period_filter_func: Callable[[Period], QuerySet]
+    period_filter_func: Callable[[QuerySet, Period], QuerySet]
     categories: List[ADXMappingCategoryDefinition]
 
 
@@ -35,6 +35,7 @@ class ADXMappingGroupDefinition:
     comment: str
     dataset: Type[Model]  # HF Etc.
     data_values: List[ADXMappingDataValueDefinition]
+    to_org_unit_code_func: Callable[[Model], str]
 
     @property
     def dataset_repr(self) -> str:

--- a/dhis2_etl/scheduled_tasks/__init__.py
+++ b/dhis2_etl/scheduled_tasks/__init__.py
@@ -1,4 +1,4 @@
-import datetime
+import logging
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -9,6 +9,8 @@ from dhis2_etl.scheduled_tasks.utils import sync_product_if_changed, sync_option
 from dhis2_etl.services.claimServices import syncClaim
 from dhis2_etl.services.fundingServices import sync_funding
 from dhis2_etl.services.insureeServices import syncPolicy
+
+logger = logging.getLogger(__name__)
 
 SYNC_FUNCTIONS = [
     SyncFunction("claim", syncClaim, GeneralConfiguration.get_scheduled_integration('claims')),

--- a/dhis2_etl/tests/__init__.py
+++ b/dhis2_etl/tests/__init__.py
@@ -1,2 +1,2 @@
-from .adx_tests import ADXTestCase
+from .adx_tests import ADXTests
 from .daily_sync_tests import DailySyncTests

--- a/dhis2_etl/tests/adx_tests.py
+++ b/dhis2_etl/tests/adx_tests.py
@@ -4,6 +4,7 @@ from typing import List
 from xml.etree import ElementTree
 
 from django.test import TestCase
+
 from location.models import HealthFacility, Location
 
 from dhis2_etl.adx_transform.formatters import XMLFormatter
@@ -19,17 +20,17 @@ from location.test_helpers import create_test_health_facility
 from dhis2_etl.adx_transform.adx_models.adx_time_period import ISOFormatPeriodType, PeriodParsingException
 
 
-class ADXTestCase(TestCase):
-    _50_YEARS_AGO = datetime.datetime(2022, 7, 1)-datetime.timedelta(days=365*50)
+class ADXTests(TestCase):
+    _50_YEARS_AGO = datetime.datetime(2022, 7, 1) - datetime.timedelta(days=365 * 50)
     AGE_CATEGORY_DEFINITION = ADXMappingCategoryDefinition(
         category_name="ageGroup",
         category_options=[
             ADXCategoryOptionDefinition(
                 code="<=50yo",
-                filter=lambda insuree_qs: insuree_qs.filter(dob__gte=ADXTestCase._50_YEARS_AGO)),
+                filter=lambda insuree_qs: insuree_qs.filter(dob__gte=ADXTests._50_YEARS_AGO)),
             ADXCategoryOptionDefinition(
                 code=">50yo",
-                filter=lambda insuree_qs: insuree_qs.filter(dob__lt=ADXTestCase._50_YEARS_AGO))
+                filter=lambda insuree_qs: insuree_qs.filter(dob__lt=ADXTests._50_YEARS_AGO))
         ]
     )
     SEX_CATEGORY_DEFINITION = ADXMappingCategoryDefinition(
@@ -48,12 +49,15 @@ class ADXTestCase(TestCase):
         groups=[
             ADXMappingGroupDefinition(
                 comment="Test Comment",
-                to_org_unit_code_func= lambda l: build_dhis2_id(l.uuid),
+                dataset=HealthFacility,
+                to_org_unit_code_func=lambda hf: build_dhis2_id(hf.uuid),
                 data_values=[
                     ADXMappingDataValueDefinition(
                         data_element="NB_INSUREES",
                         dataset_from_orgunit_func=lambda hf: hf.insurees,
-                        aggregation_func=lambda insuress_qs: str(insuress_qs.count()),
+                        aggregation_func=lambda insurees_qs: str(insurees_qs.count()),
+                        period_filter_func=lambda qs, period: qs.filter(validity_from__gte=period.from_date,
+                                                                        validity_from__lte=period.to_date),
                         categories=[AGE_CATEGORY_DEFINITION, SEX_CATEGORY_DEFINITION]
                     )
                 ]
@@ -67,12 +71,15 @@ class ADXTestCase(TestCase):
         groups=[
             ADXMappingGroupDefinition(
                 comment="Test Comment",
-                to_org_unit_code_func= lambda l: build_dhis2_id(l.uuid),
+                dataset=HealthFacility,
+                to_org_unit_code_func=lambda hf: build_dhis2_id(hf.uuid),
                 data_values=[
                     ADXMappingDataValueDefinition(
                         data_element="NB_INSUREES",
                         dataset_from_orgunit_func=lambda hf: hf.insurees,
                         aggregation_func=lambda insuress_qs: str(insuress_qs.count()),
+                        period_filter_func=lambda qs, period: qs.filter(validity_from__gte=period.from_date,
+                                                                        validity_from__lte=period.to_date),
                         categories=[]
                     )
                 ]
@@ -201,9 +208,9 @@ class ADXTestCase(TestCase):
     def _create_test_insuree(cls, chfid: str, sex: str, dob: str, validity: str) -> List[Insuree]:
         return create_test_insuree(
             True,
-            {'chf_id': chfid,
-             'gender': Gender.objects.get(code=sex),
-             'dob': dob,
-             'health_facility': cls._TEST_HF,
-             'validity_from': validity}
+            custom_props={'chf_id': chfid,
+                          'gender': Gender.objects.get(code=sex),
+                          'dob': dob,
+                          'health_facility': cls._TEST_HF,
+                          'validity_from': validity}
         )

--- a/dhis2_etl/tests/daily_sync_tests.py
+++ b/dhis2_etl/tests/daily_sync_tests.py
@@ -148,8 +148,8 @@ class DailySyncTests(TestCase):
     def _create_test_insuree(cls, chfid: str, sex: str, dob: str, validity: str) -> List[Insuree]:
         return create_test_insuree(
             True,
-            {'chf_id': chfid,
-             'gender': Gender.objects.get(code=sex),
-             'dob': dob,
-             'validity_from': validity}
+            custom_props={'chf_id': chfid,
+                          'gender': Gender.objects.get(code=sex),
+                          'dob': dob,
+                          'validity_from': validity}
         )


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OIF-11](https://openimis.atlassian.net/browse/OIF-11)

Changes:
- Fixed broken test setup
- Added missing args in test adx definitions
- Moved `to_org_unit_code_func` from Builder to Group definition